### PR TITLE
Fix crash of bili-header caused by stats injection

### DIFF
--- a/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
+++ b/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
@@ -270,7 +270,8 @@ VCUtil.Entry = () => {
     const flag = VCUtil.ConfigFlags[urlInfo.type];
     if (flag.stdurl) VCUtil.URL.Standardize(urlInfo);
     if (flag.stdurlAll) VCUtil.URL.StandardizeAllUrl();
-    if (flag.stat) { VCUtil.Stat.FetchData(urlInfo.avid, urlInfo.part); }
+    if (document.querySelector('div.bili-avatar'))
+        if (flag.stat) { VCUtil.Stat.FetchData(urlInfo.avid, urlInfo.part); }
 }
 
 VCUtil.MenuCommand = {


### PR DESCRIPTION
When using the script v3.1.5 with Firefox 132.0, the page header may become blank.

It is observed that the page header loading is a 2-step process. The script injects the div for the video stats before the 2nd phase of the header loading, and likely brings some error to the header loading, resulting in a blank header.

The proposed change injects the stats div after checking the presence of `div.bili-avatar`, which indicates that the header is completely loaded.

Before:
![image](https://github.com/user-attachments/assets/430fe944-23c1-4faa-9a5d-3a9717b700a2)
After:
![image](https://github.com/user-attachments/assets/5b574d5e-6280-4939-a24b-d257a3cbe197)
