### PR TITLE
Added support for /festival/ links, ensured that videoId stays correct when switching with video pod

### DIFF
--- a/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
+++ b/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
@@ -13,6 +13,7 @@
 // @compatible   chrome
 // @compatible   edge
 // @match        *://www.bilibili.com/video/*
+// @match        *://www.bilibili.com/festival/*
 // @match        *://www.bilibili.com/list/watchlater*
 // @match        *://www.bilibili.com/list/ml*
 // @grant        GM_registerMenuCommand
@@ -25,6 +26,7 @@
 const VCUtil = {
     ConfigFlags: {
         video:      { stdurl: true, stdurlAll: true, stat: true },
+        festival:   { stdurl: true, stdurlAll: true, stat: true },
         watchlater: { stdurl: true, stdurlAll: true, stat: true },
         medialist:  { stdurl: true, stdurlAll: true, stat: true },
         timezoneSlotsCount: 3,
@@ -70,14 +72,28 @@ VCUtil.Convert = {
 VCUtil.URL = {
     Info: function () {
         if (location.pathname.startsWith("/video/")) {
-            const videoId = window.location.pathname
-                .slice('/video/'.length)
+            const actualVideo = document.querySelector("meta[property=\"og:url\"]").content;
+            const videoId = actualVideo
+                .slice('https://www.bilibili.com/video/'.length)
                 .replace(/\/$/, '');
             const avid = videoId.startsWith('av') ? Number(videoId.slice(2)) : VCUtil.Convert.bv2av(videoId);
             const part = new URL(window.location.href).searchParams.get("p") || 1;
             return {
                 avid: avid, bvid: VCUtil.Convert.av2bv(avid), part: part, type: 'video',
                 standardUrl: `https://www.bilibili.com/video/av${avid}${part > 1 ? `?p=${part}` : ''}`
+            };
+        }
+        if (location.pathname.startsWith("/festival/")) {
+            const actualVideo = document.querySelector("#link0").value;
+            const fesName = location.pathname.slice('/festival/'.length);
+            const videoId = actualVideo
+                .slice('https://www.bilibili.com/video/'.length)
+                .replace(/\/$/, '');
+            const avid = videoId.startsWith('av') ? Number(videoId.slice(2)) : VCUtil.Convert.bv2av(videoId);
+            const part = new URL(actualVideo).searchParams.get("p") || 1;
+            return {
+                avid: avid, bvid: VCUtil.Convert.av2bv(avid), part: part, type: 'festival',
+                standardUrl: `https://www.bilibili.com/festival/${fesName}?bvid=${VCUtil.Convert.av2bv(avid)}${part > 1 ? `&p=${part}` : ''}`
             };
         }
         if (location.pathname.startsWith("/list/watchlater")) {
@@ -185,7 +201,11 @@ VCUtil.Stat = {
     UpdateLayout: function () {
         const infoBox = document.querySelector(VCUtil.Stat.InfoBoxClass);
         if (infoBox) {
-            document.querySelector(".video-info-meta").parentElement.style.paddingBottom = `${infoBox.clientHeight + 80}px`;
+            if(document.querySelector(".video-info-meta")) {
+                document.querySelector(".video-info-meta").parentElement.style.paddingBottom = `${infoBox.clientHeight + 80}px`;
+            } else {
+                document.querySelector(".video-desc").style.paddingTop = `${infoBox.clientHeight}px`;
+            }
         }
     },
 
@@ -200,7 +220,11 @@ VCUtil.Stat = {
         infoBox.style.zIndex = "10";
         infoBox.style.paddingTop = "10px";
         Array.from(document.querySelectorAll(VCUtil.Stat.InfoBoxClass)).forEach(e => e.remove());
-        document.querySelector(".video-info-meta").parentElement.appendChild(infoBox);
+        if(document.querySelector(".video-info-meta") != null) {
+            document.querySelector(".video-info-meta").parentElement.appendChild(infoBox);
+        } else {
+            document.querySelector(".video-desc").parentElement.insertBefore(infoBox, document.querySelector(".video-desc"))
+        }
         const builder = {
             AddText: function (text, code = false) {
                 const textBox = document.createElement("span");

--- a/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
+++ b/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
@@ -220,7 +220,7 @@ VCUtil.Stat = {
         infoBox.style.zIndex = "10";
         infoBox.style.paddingTop = "10px";
         Array.from(document.querySelectorAll(VCUtil.Stat.InfoBoxClass)).forEach(e => e.remove());
-        if(document.querySelector(".video-info-meta") != null) {
+        if(document.querySelector(".video-info-meta")) {
             document.querySelector(".video-info-meta").parentElement.appendChild(infoBox);
         } else {
             document.querySelector(".video-desc").parentElement.insertBefore(infoBox, document.querySelector(".video-desc"))


### PR DESCRIPTION
When using the script v3.1.6, festival links do not get the info box, and when switching a video with the video pod tool, the info box stays the same, as opposed to the expected behavior of changing into the new video.

The proposed change injects the infobox before `.video.desc` if `.video-info-meta` is not present, and uses `meta[property="og:url"]` (for videos), and `#link0` (for festivals) to retrieve the videoId of the actual video instead of `window.location.href`.

Before (av26586543 is the aid of [双向倾诉](https://www.bilibili.com/video/av26586543)):
![image](https://github.com/user-attachments/assets/5a58a7a8-84d9-4a24-8d45-715960600b70)
After:
https://github.com/user-attachments/assets/74c841ff-905a-48a7-ba26-05d4f6a87735 (Video, notice how the location changes and how the views behave)

Before:
![image](https://github.com/user-attachments/assets/b1d5e72e-4953-45a0-813e-090e66364292)
After:
![image](https://github.com/user-attachments/assets/62fc5744-2f4c-45da-af8b-3c8a378fa6ab)
