### PR TITLE
Added support for tid v2 and added ability to show tid along with tname (disabled by default); replaced the bilibili API endpoint to achieve said goals; changed the way achievements behave due to improper tid tagging of bilibili's new system; fixed the instance where guest bilibili users could not use this script

### DIFF
--- a/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
+++ b/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
@@ -31,6 +31,8 @@ const VCUtil = {
         medialist:  { stdurl: true, stdurlAll: true, stat: true },
         timezoneSlotsCount: 3,
         timezoneSlotDefault: ['PVG', 'NRT', 'LAX'],
+        tidVersionDefault: 'v1',
+        tidShowDefault: false,
     },
 };
 
@@ -158,7 +160,7 @@ VCUtil.Stat = {
         if (!document.querySelector('div.bili-avatar')) return console.log("[B站视频统计] [Stat] Header 未完全加载，推迟 FetchData");
         if (document.querySelector(VCUtil.Stat.InfoBoxClass)
           && document.querySelector(VCUtil.Stat.InfoBoxClass).getAttribute('data-avid') === avid.toString()) return;
-        const url = `https://api.bilibili.com/medialist/gateway/base/resource/info?rid=${avid}&type=2`;
+        const url = `https://api.bilibili.com/x/web-interface/view?aid=${avid}`;
         console.log("[B站视频统计] [Stat] FetchData:", `HTTP GET ${url}`);
         const response = await fetch(url);
         console.log("[B站视频统计] [Stat] FetchData: Response", response);
@@ -169,18 +171,21 @@ VCUtil.Stat = {
         if (data == undefined) return;
 
         const format = VCUtil.Stat.Format;
+        const tidVersion = VCUtil.MenuCommand.CurrentAndNextTid().current.Id;
+        const tidShow = VCUtil.MenuCommand.CurrentAndNextTidShow().current;
         const block = VCUtil.Stat
             .BuildInfoBox(avid)
-            .AddText(`${format.HumanReadableNumber(data.cnt_info.play)} 播放    `)
-            .AddText(format.Tname(data.tid))
+            .AddText(`${format.HumanReadableNumber(data.stat.view)} 播放    `)
+            .AddText(tidVersion != "v2" ? ((tidVersion === "all" ? "v1：" : "") + (tidShow ? `${data.tname}（${data.tid}）` : data.tname)) : "")
+            .AddText(tidVersion != "v1" ? ((tidVersion === "all" ? "v2：" : "") + (tidShow ? `${data.tname_v2}（${data.tid_v2}）` : data.tname_v2)) : "")
             .AddText(`av${avid}`, true)
             .AddText(VCUtil.Convert.av2bv(avid), true)
             .AddText(`cid=${data.pages[part - 1].id}`, true)
-            .AddText((data.tid === 30) ? format.VocaloidAchievement(data.cnt_info.play) : "非 VU 区视频")
+            .AddText((data.tid === 30) ? format.VocaloidAchievement(data.stat.view) : format.VocaloidAchievement(data.stat.view)+"（非 VU 区视频）")
             .AddLineBreak();
 
         block.AddText('发布');
-        VCUtil.Stat.FormatTimezoneSlots(block, data.pubtime);
+        VCUtil.Stat.FormatTimezoneSlots(block, data.pubdate);
         block.AddLineBreak();
         block.AddText('投稿');
         VCUtil.Stat.FormatTimezoneSlots(block, data.ctime);
@@ -192,7 +197,7 @@ VCUtil.Stat = {
             block.AddText('---');
         }
 
-        block.AddLink('封面', data.cover);
+        block.AddLink('封面', data.pic);
         block.AddLink('短链接', `https://b23.tv/av${avid}`);
         block.AddLink('API', url);
         VCUtil.Stat.UpdateLayout();
@@ -227,6 +232,7 @@ VCUtil.Stat = {
         }
         const builder = {
             AddText: function (text, code = false) {
+                if (text === "") { return builder; }
                 const textBox = document.createElement("span");
                 textBox.innerText = text + " ";
                 textBox.style.marginRight = "13px";
@@ -259,7 +265,6 @@ VCUtil.Stat = {
 };
 
 VCUtil.Stat.Format = {
-    TidMapping: [{ "id": 1, "name": "动画(主分区)" }, { "id": 24, "name": "MAD·AMV" }, { "id": 25, "name": "MMD·3D" }, { "id": 47, "name": "短片·手书" }, { "id": 257, "name": "配音" }, { "id": 210, "name": "手办·模玩" }, { "id": 86, "name": "特摄" }, { "id": 253, "name": "动漫杂谈" }, { "id": 27, "name": "综合" }, { "id": 13, "name": "番剧(主分区)" }, { "id": 51, "name": "资讯" }, { "id": 152, "name": "官方延伸" }, { "id": 32, "name": "完结动画" }, { "id": 33, "name": "连载动画" }, { "id": 167, "name": "国创(主分区)" }, { "id": 153, "name": "国产动画" }, { "id": 168, "name": "国产原创相关" }, { "id": 169, "name": "布袋戏" }, { "id": 170, "name": "资讯" }, { "id": 195, "name": "动态漫·广播剧" }, { "id": 3, "name": "音乐(主分区)" }, { "id": 28, "name": "原创音乐" }, { "id": 31, "name": "翻唱" }, { "id": 30, "name": "VOCALOID·UTAU" }, { "id": 59, "name": "演奏" }, { "id": 193, "name": "MV" }, { "id": 29, "name": "音乐现场" }, { "id": 130, "name": "音乐综合" }, { "id": 243, "name": "乐评盘点" }, { "id": 244, "name": "音乐教学" }, { "id": 194, "name": "电音(已下线)" }, { "id": 129, "name": "舞蹈(主分区)" }, { "id": 20, "name": "宅舞" }, { "id": 154, "name": "舞蹈综合" }, { "id": 156, "name": "舞蹈教程" }, { "id": 198, "name": "街舞" }, { "id": 199, "name": "明星舞蹈" }, { "id": 200, "name": "国风舞蹈" }, { "id": 255, "name": "手势·网红舞" }, { "id": 4, "name": "游戏(主分区)" }, { "id": 17, "name": "单机游戏" }, { "id": 171, "name": "电子竞技" }, { "id": 172, "name": "手机游戏" }, { "id": 65, "name": "网络游戏" }, { "id": 173, "name": "桌游棋牌" }, { "id": 121, "name": "GMV" }, { "id": 136, "name": "音游" }, { "id": 19, "name": "Mugen" }, { "id": 36, "name": "知识(主分区)" }, { "id": 201, "name": "科学科普" }, { "id": 124, "name": "社科·法律·心理(原社科人文、原趣味科普人文)" }, { "id": 228, "name": "人文历史" }, { "id": 207, "name": "财经商业" }, { "id": 208, "name": "校园学习" }, { "id": 209, "name": "职业职场" }, { "id": 229, "name": "设计·创意" }, { "id": 122, "name": "野生技术协会" }, { "id": 39, "name": "演讲·公开课(已下线)" }, { "id": 96, "name": "星海(已下线)" }, { "id": 98, "name": "机械(已下线)" }, { "id": 188, "name": "科技(主分区)" }, { "id": 95, "name": "数码(原手机平板)" }, { "id": 230, "name": "软件应用" }, { "id": 231, "name": "计算机技术" }, { "id": 232, "name": "科工机械 (原工业·工程·机械)" }, { "id": 233, "name": "极客DIY" }, { "id": 189, "name": "电脑装机(已下线)" }, { "id": 190, "name": "摄影摄像(已下线)" }, { "id": 191, "name": "影音智能(已下线)" }, { "id": 234, "name": "运动(主分区)" }, { "id": 235, "name": "篮球" }, { "id": 249, "name": "足球" }, { "id": 164, "name": "健身" }, { "id": 236, "name": "竞技体育" }, { "id": 237, "name": "运动文化" }, { "id": 238, "name": "运动综合" }, { "id": 223, "name": "汽车(主分区)" }, { "id": 258, "name": "汽车知识科普" }, { "id": 245, "name": "赛车" }, { "id": 246, "name": "改装玩车" }, { "id": 247, "name": "新能源车" }, { "id": 248, "name": "房车" }, { "id": 240, "name": "摩托车" }, { "id": 227, "name": "购车攻略" }, { "id": 176, "name": "汽车生活" }, { "id": 224, "name": "汽车文化(已下线)" }, { "id": 225, "name": "汽车极客(已下线)" }, { "id": 226, "name": "智能出行(已下线)" }, { "id": 160, "name": "生活(主分区)" }, { "id": 138, "name": "搞笑" }, { "id": 250, "name": "出行" }, { "id": 251, "name": "三农" }, { "id": 239, "name": "家居房产" }, { "id": 161, "name": "手工" }, { "id": 162, "name": "绘画" }, { "id": 21, "name": "日常" }, { "id": 254, "name": "亲子" }, { "id": 76, "name": "美食圈(重定向)" }, { "id": 75, "name": "动物圈(重定向)" }, { "id": 163, "name": "运动(重定向)" }, { "id": 176, "name": "汽车(重定向)" }, { "id": 174, "name": "其他(已下线)" }, { "id": 211, "name": "美食(主分区)" }, { "id": 76, "name": "美食制作(原[生活]->[美食圈])" }, { "id": 212, "name": "美食侦探" }, { "id": 213, "name": "美食测评" }, { "id": 214, "name": "田园美食" }, { "id": 215, "name": "美食记录" }, { "id": 217, "name": "动物圈(主分区)" }, { "id": 218, "name": "喵星人" }, { "id": 219, "name": "汪星人" }, { "id": 220, "name": "动物二创" }, { "id": 221, "name": "野生动物" }, { "id": 222, "name": "小宠异宠" }, { "id": 75, "name": "动物综合" }, { "id": 119, "name": "鬼畜(主分区)" }, { "id": 22, "name": "鬼畜调教" }, { "id": 26, "name": "音MAD" }, { "id": 126, "name": "人力VOCALOID" }, { "id": 216, "name": "鬼畜剧场" }, { "id": 127, "name": "教程演示" }, { "id": 155, "name": "时尚(主分区)" }, { "id": 157, "name": "美妆护肤" }, { "id": 252, "name": "仿妆cos" }, { "id": 158, "name": "穿搭" }, { "id": 159, "name": "时尚潮流" }, { "id": 164, "name": "健身(重定向)" }, { "id": 192, "name": "风尚标(已下线)" }, { "id": 202, "name": "资讯(主分区)" }, { "id": 203, "name": "热点" }, { "id": 204, "name": "环球" }, { "id": 205, "name": "社会" }, { "id": 206, "name": "综合" }, { "id": 165, "name": "广告(主分区)" }, { "id": 166, "name": "广告(已下线)" }, { "id": 5, "name": "娱乐(主分区)" }, { "id": 71, "name": "综艺" }, { "id": 241, "name": "娱乐杂谈" }, { "id": 242, "name": "粉丝创作" }, { "id": 137, "name": "明星综合" }, { "id": 131, "name": "Korea相关(已下线)" }, { "id": 181, "name": "影视(主分区)" }, { "id": 182, "name": "影视杂谈" }, { "id": 183, "name": "影视剪辑" }, { "id": 85, "name": "小剧场" }, { "id": 184, "name": "预告·资讯" }, { "id": 256, "name": "短片" }, { "id": 177, "name": "纪录片(主分区)" }, { "id": 37, "name": "人文·历史" }, { "id": 178, "name": "科学·探索·自然" }, { "id": 179, "name": "军事" }, { "id": 180, "name": "社会·美食·旅行" }, { "id": 23, "name": "电影(主分区)" }, { "id": 147, "name": "华语电影" }, { "id": 145, "name": "欧美电影" }, { "id": 146, "name": "日本电影" }, { "id": 83, "name": "其他国家" }, { "id": 11, "name": "电视剧(主分区)" }, { "id": 185, "name": "国产剧" }, { "id": 187, "name": "海外剧" }],
     HumanReadableNumber: function (num) {
         var result = '', counter = 0;
         num = (num || 0).toString();
@@ -278,10 +283,6 @@ VCUtil.Stat.Format = {
         if (plays >= 500000) return "专兑";
         if (plays >= 100000) return "殿堂";
         return "待成就";
-    },
-
-    Tname: function (tid) {
-        return VCUtil.Stat.Format.TidMapping.find(e => e.id === tid)?.name || "未知分区";
     },
 
     Timezone: function (timestamp, timezone) {
@@ -329,16 +330,65 @@ VCUtil.MenuCommand = {
         VCUtil.MenuCommand.Register();
         console.log(`[B站视频统计] [Menu] 时区槽位 ${slotId + 1} 设置成功`);
     },
+    TidMapping: [
+        { Id: "v1", Name: "旧版" },
+        { Id: "v2", Name: "新版" },
+        { Id: "all", Name: "全部" },
+    ],
+    CurrentAndNextTid: function () {
+        const currentId = GM_getValue("VCUtil_Tid", VCUtil.ConfigFlags.tidVersionDefault);
+        const currentIndex = VCUtil.MenuCommand.TidMapping.findIndex(e => e.Id === currentId);
+        const current = VCUtil.MenuCommand.TidMapping[currentIndex];
+        console.log(`[B站视频统计] [Menu] 分区设置 当前`, current);
+        const nextIndex = (currentIndex + 1) % VCUtil.MenuCommand.TidMapping.length;
+        const next = VCUtil.MenuCommand.TidMapping[nextIndex];
+        console.log(`[B站视频统计] [Menu] 分区设置 下个`, next);
+        return { current: current, next: next };
+    },
+    ChangeTidSetting: function () {
+        const { next } = VCUtil.MenuCommand.CurrentAndNextTid();
+        GM_setValue("VCUtil_Tid", next.Id);
+        VCUtil.MenuCommand.Register();
+        console.log(`[B站视频统计] [Menu] 分区设置 设置成功`);
+    },
+    CurrentAndNextTidShow: function () {
+        const current = GM_getValue("VCUtil_TidShow", VCUtil.ConfigFlags.tidShowDefault);
+        console.log(`[B站视频统计] [Menu] 分区Id显示设置 当前`, current);
+        console.log(`[B站视频统计] [Menu] 分区Id显示设置 下个`, !current);
+        return { current: current, next: !current };
+    },
+    ChangeTidShowSetting: function () {
+        const { next } = VCUtil.MenuCommand.CurrentAndNextTidShow();
+        GM_setValue("VCUtil_TidShow", next);
+        VCUtil.MenuCommand.Register();
+        console.log(`[B站视频统计] [Menu] 分区Id显示设置 设置成功`);
+    },
     Register: function () {
         VCUtil.MenuCommand.MenuCommands.forEach(meunCommandId => GM_unregisterMenuCommand(meunCommandId));
         VCUtil.MenuCommand.MenuCommands = [];
         for (let slotId = 0; slotId < VCUtil.ConfigFlags.timezoneSlotsCount; slotId++) {
             const { current, next } = VCUtil.MenuCommand.CurrentAndNextTimezone(slotId);
-            const meunCommandId = GM_registerMenuCommand(
+            const menuCommandId = GM_registerMenuCommand(
                 `切换槽位 ${slotId + 1} 时区 ${current.IATA} -> ${next.IATA}`,
                 () => VCUtil.MenuCommand.ChangeTimezoneSetting(slotId),
             );
-            VCUtil.MenuCommand.MenuCommands.push(meunCommandId);
+            VCUtil.MenuCommand.MenuCommands.push(menuCommandId);
+        }
+        {
+            const { current, next } = VCUtil.MenuCommand.CurrentAndNextTid();
+            const menuCommandId = GM_registerMenuCommand(
+                `切换分区显示 ${current.Name} -> ${next.Name}`,
+                () => VCUtil.MenuCommand.ChangeTidSetting(),
+            );
+            VCUtil.MenuCommand.MenuCommands.push(menuCommandId);
+        }
+        {
+            const { next } = VCUtil.MenuCommand.CurrentAndNextTidShow();
+            const menuCommandId = GM_registerMenuCommand(
+                `${next ? "开启" : "关闭"}分区id显示`,
+                () => VCUtil.MenuCommand.ChangeTidShowSetting(),
+            );
+            VCUtil.MenuCommand.MenuCommands.push(menuCommandId);
         }
     }
 };

--- a/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
+++ b/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
@@ -157,7 +157,7 @@ VCUtil.Stat = {
         }
     },
     FetchData: async function (avid, part) {
-        if (!document.querySelector('div.bili-avatar')) return console.log("[B站视频统计] [Stat] Header 未完全加载，推迟 FetchData");
+        if (!document.querySelector('div.bili-avatar') && !document.querySelector('div.header-login-entry')) return console.log("[B站视频统计] [Stat] Header 未完全加载，推迟 FetchData");
         if (document.querySelector(VCUtil.Stat.InfoBoxClass)
           && document.querySelector(VCUtil.Stat.InfoBoxClass).getAttribute('data-avid') === avid.toString()) return;
         const url = `https://api.bilibili.com/x/web-interface/view?aid=${avid}`;

--- a/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
+++ b/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
@@ -176,12 +176,9 @@ VCUtil.Stat = {
         const block = VCUtil.Stat
             .BuildInfoBox(avid)
             .AddText(`${format.HumanReadableNumber(data.stat.view)} 播放    `)
-            .AddText(tidVersion != "v2" ? ((tidVersion === "all" ? "v1：" : "") + (tidShow ? `${data.tname}（${data.tid}）` : data.tname)) : "")
-            .AddText(tidVersion != "v1" ? ((tidVersion === "all" ? "v2：" : "") + (tidShow ? `${data.tname_v2}（${data.tid_v2}）` : data.tname_v2)) : "")
             .AddText(`av${avid}`, true)
             .AddText(VCUtil.Convert.av2bv(avid), true)
             .AddText(`cid=${data.pages[part - 1].cid}`, true)
-            .AddText((data.tid === 30) ? format.VocaloidAchievement(data.stat.view) : format.VocaloidAchievement(data.stat.view)+"（非 VU 区视频）")
             .AddLineBreak();
 
         block.AddText('发布');
@@ -189,7 +186,13 @@ VCUtil.Stat = {
         block.AddLineBreak();
         block.AddText('投稿');
         VCUtil.Stat.FormatTimezoneSlots(block, data.ctime);
-        block.AddLineBreak();
+        block
+            .AddLineBreak()
+            .AddText('分区')
+            .AddText(tidVersion != "v2" ? ((tidVersion === "all" ? "v1 " : "") + (tidShow ? `${data.tname}（${data.tid}）` : data.tname)) : "")
+            .AddText(tidVersion != "v1" ? ((tidVersion === "all" ? "v2 " : "") + (tidShow ? `${data.tname_v2}（${data.tid_v2}）` : data.tname_v2)) : "")
+            .AddText((data.tid === 30) ? format.VocaloidAchievement(data.stat.view) : format.VocaloidAchievement(data.stat.view)+"（非 VU 区视频）")
+            .AddLineBreak();
 
         if (data.tid === 30) {
             block.AddLink('TDD',`https://tdd.bunnyxt.com/video/av${avid}`)

--- a/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
+++ b/tampermonkey/bilibili-vcutils/bilibili-vcutils.js
@@ -180,7 +180,7 @@ VCUtil.Stat = {
             .AddText(tidVersion != "v1" ? ((tidVersion === "all" ? "v2：" : "") + (tidShow ? `${data.tname_v2}（${data.tid_v2}）` : data.tname_v2)) : "")
             .AddText(`av${avid}`, true)
             .AddText(VCUtil.Convert.av2bv(avid), true)
-            .AddText(`cid=${data.pages[part - 1].id}`, true)
+            .AddText(`cid=${data.pages[part - 1].cid}`, true)
             .AddText((data.tid === 30) ? format.VocaloidAchievement(data.stat.view) : format.VocaloidAchievement(data.stat.view)+"（非 VU 区视频）")
             .AddLineBreak();
 


### PR DESCRIPTION
I received an FR to added support for tid v2 and I thought they would be helpful.
As of the not recent VCPedia talk regarding updated standards of achievements and the fact that moegirlpedia did not update said standards, a warning is added for non-VOCALOID-tidded (tid !== 30) videos instead of replacing the entirety of the achievements display.
The ability to show tid was just something I've always wanted.
I also fixed the issue where guest users could not use this script. As they don't have `div.bili-avatar` and have `div.header-login-entry` instead, the script is stuck at loading headers and could not initiate its normal logic.
Before:
<img width="703" height="160" alt="image" src="https://github.com/user-attachments/assets/f1e25076-ae1e-4f4e-bc20-eaed754ff1b5" />
After:
(Showing all versions and tid)
<img width="1140" height="160" alt="image" src="https://github.com/user-attachments/assets/2675aee0-41dd-41fa-a863-0d42915e9668" />
(Showing only v1 and tid)
<img width="1140" height="160" alt="image" src="https://github.com/user-attachments/assets/ba7abbe4-65e1-4bef-b924-937827b57c87" />
(Showing only v2 and no tid)
<img width="1140" height="160" alt="image" src="https://github.com/user-attachments/assets/120d92f8-746f-4c53-9717-d00993ccf6df" />
(The configuration menu)
<img width="283" height="415" alt="image" src="https://github.com/user-attachments/assets/169198f7-c810-43f6-a2d6-8b83f5ed61e0" />